### PR TITLE
removed redundant block explorer keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,3 @@
-# api keys is used to verify contracts
-ETHERSCAN_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-POLYGONSCAN_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
 # RPC endpoint API keys
 API_KEY_RPC_MAINNET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 API_KEY_RPC_SEPOLIA=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
- removed redundant block explorer keys from the .env.example file